### PR TITLE
adds paging to Key.GetAll

### DIFF
--- a/PhraseStrings.Api/Interfaces/IKeyService.cs
+++ b/PhraseStrings.Api/Interfaces/IKeyService.cs
@@ -2,7 +2,7 @@
 
 public interface IKeyService
 {
-    Task<List<Key>?> GetAll(string projectId);
+    Task<List<Key>?> GetAll(string projectId, int perPage = 100, int? page = null);
 
     Task<Key?> GetById(string projectId, string keyId);
 

--- a/PhraseStrings.Api/Services/KeyService.cs
+++ b/PhraseStrings.Api/Services/KeyService.cs
@@ -6,9 +6,38 @@ internal class KeyService : BaseService, IKeyService
     {
     }
 
-    public async Task<List<Key>?> GetAll(string projectId)
+    public async Task<List<Key>?> GetAll(string projectId, int perPage = 100, int? page = null)
     {
-        return await GetList<List<Key>>($"projects/{projectId}/keys");
+        string url = $"projects/{projectId}/keys?per_page={perPage}";
+
+        List<Key> results = new();
+        int maxPages = 10000;
+
+        if (page.HasValue)
+        {
+            return await GetList<List<Key>>($"{url}&page={page}");
+        }
+        else
+        {
+            // Phrase doesn't return the total number of pages, so we have to guess
+            page = 1;
+
+            while (page < maxPages)
+            {
+                var pageResults = await GetList<List<Key>>($"{url}&page={page}");
+                if (pageResults is not null && pageResults.Any())
+                {
+                    results.AddRange(pageResults);
+                    page++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        return results;
     }
 
     public async Task<Key?> GetById(string projectId, string keyId)


### PR DESCRIPTION
List keys API has paging and by default page size is 25 items. With the current API, I can't fetch other items without page and page size query parameters.