### PR TITLE
Adds rate limit info

### DIFF
--- a/PhraseStrings.Api/Interfaces/ILocalizationClient.cs
+++ b/PhraseStrings.Api/Interfaces/ILocalizationClient.cs
@@ -9,5 +9,10 @@ public interface ILocalizationClient
     IKeyService Keys { get; }
 
     IWebhookService Webhooks { get; }
-}
 
+    int? NumberOfAllowedRequests { get; }
+
+    int? NumberOfRemainingRequests { get; }
+
+    DateTimeOffset? DateTimeOfLimitReseting { get; }
+}

--- a/PhraseStrings.Api/Model/LimitVariables.cs
+++ b/PhraseStrings.Api/Model/LimitVariables.cs
@@ -1,0 +1,17 @@
+﻿namespace PhraseStrings.Api.Model
+{
+    internal static class LimitVariables
+    {
+        public static object NumberOfAllowedRequestsLock { get; } = new object();
+
+        public static object NumberOfRemainingRequestsLock { get; } = new object();
+
+        public static object DateTimeOfLimitResetingLock { get; } = new object();
+
+        public static int? NumberOfAllowedRequests { get; set; }
+
+        public static int? NumberOfRemainingRequests { get; set; }
+
+        public static DateTimeOffset? DateTimeOfLimitReseting { get; set; }
+    }
+}

--- a/PhraseStrings.Api/PhraseClient.cs
+++ b/PhraseStrings.Api/PhraseClient.cs
@@ -40,4 +40,37 @@ public class PhraseClient : ILocalizationClient
     public IKeyService Keys => _keys ??= new KeyService(_httpClient);
 
     public IWebhookService Webhooks => _webhooks ??= new WebhookService(_httpClient);
+
+    public int? NumberOfAllowedRequests
+    {
+        get
+        {
+            lock (LimitVariables.NumberOfAllowedRequestsLock)
+            {
+                return LimitVariables.NumberOfAllowedRequests;
+            }
+        }
+    }
+
+    public int? NumberOfRemainingRequests
+    {
+        get
+        {
+            lock (LimitVariables.NumberOfRemainingRequestsLock)
+            {
+                return LimitVariables.NumberOfRemainingRequests;
+            }
+        }
+    }
+
+    public DateTimeOffset? DateTimeOfLimitReseting
+    {
+        get
+        {
+            lock (LimitVariables.DateTimeOfLimitResetingLock)
+            {
+                return LimitVariables.DateTimeOfLimitReseting;
+            }
+        }
+    }
 }

--- a/PhraseStrings.Api/Services/BaseService.cs
+++ b/PhraseStrings.Api/Services/BaseService.cs
@@ -8,6 +8,10 @@ namespace PhraseStrings.Api.Services;
 
 internal abstract class BaseService
 {
+    private const string XRateLimitLimitHeader = "X-Rate-Limit-Limit";
+    private const string XRateLimitRemainingHeader = "X-Rate-Limit-Remaining";
+    private const string XRateLimitResetHeader = "X-Rate-Limit-Reset";    
+
     protected HttpClient HttpClient;
     protected JsonSerializerOptions JsonSerializerOptions;
 
@@ -26,6 +30,8 @@ internal abstract class BaseService
     {
         var result = await HttpClient.GetAsync(requestUri);
 
+        ReadLimitVariables(result);
+
         if (result.StatusCode == System.Net.HttpStatusCode.NotFound)
             return default;
 
@@ -38,6 +44,7 @@ internal abstract class BaseService
     {
         var result = await HttpClient.GetAsync(requestUri);
 
+        ReadLimitVariables(result);
         HandleError(result);
 
         return await HandleResult<TResult>(result);
@@ -61,6 +68,7 @@ internal abstract class BaseService
             result = await HttpClient.SendAsync(requestMessage);
         }
 
+        ReadLimitVariables(result);
         HandleError(result);
 
         return await HandleResult<TResult>(result);
@@ -71,6 +79,7 @@ internal abstract class BaseService
         var data = request.ToPhraseDatasKeyValue();
         var result = await HttpClient.PatchAsync(requestUri, new FormUrlEncodedContent(data));
 
+        ReadLimitVariables(result);
         HandleError(result);
 
         return await HandleResult<TResult>(result);
@@ -106,6 +115,47 @@ internal abstract class BaseService
 
             default:
                 throw new Exception($"An error occured: {responseMessage.StatusCode}");
+        }
+    }
+
+    private void ReadLimitVariables(HttpResponseMessage response)
+    {
+        if (response is null)
+            return;
+
+        var headers = response.Headers;
+
+        if (headers.Contains(XRateLimitLimitHeader) && headers.TryGetValues(XRateLimitLimitHeader, out IEnumerable<string>? xRateLimitLimitHeaderValues))
+        {
+            if (int.TryParse(xRateLimitLimitHeaderValues?.FirstOrDefault(), out int result))
+            {
+                lock (LimitVariables.NumberOfAllowedRequestsLock)
+                {
+                    LimitVariables.NumberOfAllowedRequests = result;
+                }
+            }
+        }
+
+        if (headers.Contains(XRateLimitRemainingHeader) && headers.TryGetValues(XRateLimitRemainingHeader, out IEnumerable<string>? xRateLimitRemainingHeaderValues))
+        {
+            if (int.TryParse(xRateLimitRemainingHeaderValues?.FirstOrDefault(), out int result))
+            {
+                lock (LimitVariables.NumberOfRemainingRequestsLock)
+                {
+                    LimitVariables.NumberOfRemainingRequests = result;
+                }
+            }
+        }
+
+        if (headers.Contains(XRateLimitResetHeader) && headers.TryGetValues(XRateLimitResetHeader, out IEnumerable<string>? values))
+        {
+            if (long.TryParse(values?.FirstOrDefault(), out long result))
+            {
+                lock (LimitVariables.DateTimeOfLimitResetingLock)
+                {
+                    LimitVariables.DateTimeOfLimitReseting = DateTimeOffset.FromUnixTimeSeconds(result);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I reached the rate limit of APIs when was working with projects. I'd like to know how many requests are left and when the limit will reset.
Pull request adds rate limits variables to phraseApiClient from HTTP response headers "X-Rate-Limit-Limit", "X-Rate-Limit-Remaining", and "X-Rate-Limit-Reset".